### PR TITLE
fix paths used in the init.sh file

### DIFF
--- a/installWittyPi.sh
+++ b/installWittyPi.sh
@@ -11,6 +11,8 @@ if [ "$(id -u)" != 0 ]; then
   exit 1
 fi
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/wittyPi"
+
 echo '================================================================================'
 echo '|                                                                              |'
 echo '|                   Witty Pi Software Installing Script                        |'
@@ -77,7 +79,7 @@ else
   chmod +x daemon.sh
   chmod +x syncTime.sh
   chmod +x runScript.sh
-  cp init.sh /etc/init.d/wittypi
+  sed  -e "s#/home/pi/wittyPi#$DIR#g" init.sh >/etc/init.d/wittypi
   chmod +x /etc/init.d/wittypi
   update-rc.d wittypi defaults
   cd ..


### PR DESCRIPTION
Determine the location the installWittyPi.sh script is being run from and use that path for the path to daemon.sh in the init.d script.